### PR TITLE
feat(lint): add css imports to lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,11 @@
 							{
 								"pattern": "@nestjs-starter/**",
 								"group": "internal"
+							},
+							{
+								"pattern": "*.+(css|sass|less|scss|pcss|styl)",
+								"patternOptions": { "dot": true, "nocomment": true, "matchBase": true },
+								"group": "unknown"
 							}
 						],
 						"groups": [
@@ -52,7 +57,8 @@
 							"internal",
 							["index", "sibling", "parent"],
 							"object",
-							"type"
+							"type",
+							"unknown"
 						],
 						"newlines-between": "always",
 						"pathGroupsExcludedImportTypes": ["type"]


### PR DESCRIPTION
# 🛠 What does this PR do?

This PR fixes an issue where plain css imports messed up the lint rule of ordering inputs.

You can basically use the `pattern` to add any file extensions in the future.

# 🫀 How did this PR make you feel?

![made me feel](https://media.tenor.com/zn_bDWVMmekAAAAC/order-speaker.gif)
